### PR TITLE
Replace deprecated curly brace syntax

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -103,7 +103,7 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
         );
         $profilefields = $DB->get_records('user_info_field', array());
         foreach ($profilefields as $profilefield) {
-            $exportedfields{'profile_field_'.$profilefield->shortname} = 'privacy:metadata:profilefield';
+            $exportedfields['profile_field_'.$profilefield->shortname] = 'privacy:metadata:profilefield';
         }
         $items->add_external_location_link(
             'samlidp_provider',


### PR DESCRIPTION
The provider.php used deprecated curly brace syntax for accessing array elements, which causes it to fail in PHP 8.0+ which Moodle 4.2 and later depend on and is supported since Moodle 4.1.

This caused Adhoc Tasks from tool_dataprivacy to fail when loading the provider of auth_samlidp.